### PR TITLE
fixed issue that occured when tile ghosts were in the selection area

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -385,6 +385,11 @@ local function on_player_selected_area(e)
                 end
                 goto continue
             end
+            
+            --skip the entity if it is a tile ghost
+            if entity.type == "tile-ghost" then
+                goto continue
+            end
 
             local is_ghost = entity.type == "entity-ghost"
             local function ent_prop(field)


### PR DESCRIPTION
Fixes an issue were attempting to select an area that contained a tile ghost would show an error in the chat window and prevent modules from being inserted